### PR TITLE
Add correct remeda version as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "homepage": "https://github.com/AndreaPontrandolfo/eslint-plugin-remeda",
   "bugs": "https://github.com/AndreaPontrandolfo/eslint-plugin-remeda/issues",
   "peerDependencies": {
-    "eslint": ">=9.0.0"
+    "eslint": ">=9.0.0",
+    "remeda": "^1.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.4",
@@ -53,6 +54,7 @@
     "knip": "^5.29.1",
     "prettier": "^3.3.2",
     "publint": "^0.2.10",
+    "remeda": "^1.0.0",
     "semantic-release": "^24.0.0",
     "tsup": "^8.2.4",
     "typescript": "^5.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       publint:
         specifier: ^0.2.10
         version: 0.2.10
+      remeda:
+        specifier: ^1.0.0
+        version: 1.61.0
       semantic-release:
         specifier: ^24.0.0
         version: 24.1.0(typescript@5.5.4)
@@ -3033,6 +3036,9 @@ packages:
   regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
     hasBin: true
+
+  remeda@1.61.0:
+    resolution: {integrity: sha512-caKfSz9rDeSKBQQnlJnVW3mbVdFgxgGWQKq1XlFokqjf+hQD5gxutLGTTY2A/x24UxVyJe9gH5fAkFI63ULw4A==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -7056,6 +7062,8 @@ snapshots:
   regjsparser@0.10.0:
     dependencies:
       jsesc: 0.5.0
+
+  remeda@1.61.0: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
This pull requests adds a warning if you are installing this version with remeda v2