### PR TITLE
bugfix: closes FIx release CI #32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,9 @@ jobs:
         with:
           node-version-file: package.json
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: pnpm install
       - name: Release
         run: pnpm semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,10 @@
   },
   "packageManager": "pnpm@9.9.0",
   "publishConfig": {
-    "access": "public"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "tag": "latest",
+    "provenance": true
   },
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint": ">=9.0.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "packageManager": "pnpm@9.9.0",
   "publishConfig": {


### PR DESCRIPTION
Closes #32 
BREAKING-CHANGE: bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow simplified to use default registry settings and removed explicit token usage.
  * Package configuration updated: Node engine requirement raised to >=22 and publish settings expanded to include registry, default tag, and provenance while keeping public access.

---

*Note: Infrastructure changes only; no direct user-facing feature updates.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->