### PR TITLE
refactor: replace lodash with native js

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import eslintPlugin from "eslint-plugin-eslint-plugin";
 
 const sheriffOptions = {
   react: false,
-  lodash: true,
+  lodash: false,
   remeda: false,
   next: false,
   astro: false,

--- a/package.json
+++ b/package.json
@@ -45,13 +45,9 @@
   },
   "homepage": "https://github.com/AndreaPontrandolfo/eslint-plugin-remeda",
   "bugs": "https://github.com/AndreaPontrandolfo/eslint-plugin-remeda/issues",
-  "dependencies": {
-    "lodash-es": "^4.17.21"
-  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
     "@sherifforg/cli": "^8.7.0",
-    "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.14.0",
     "@typescript-eslint/utils": "^8.46.2",
     "@vitest/coverage-v8": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -18,9 +14,6 @@ importers:
       '@sherifforg/cli':
         specifier: ^8.7.0
         version: 8.7.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
       '@types/node':
         specifier: ^22.14.0
         version: 22.14.0
@@ -911,12 +904,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/lodash-es@4.17.12':
-    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
-
-  '@types/lodash@4.17.20':
-    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
@@ -4747,12 +4734,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/lodash-es@4.17.12':
-    dependencies:
-      '@types/lodash': 4.17.20
-
-  '@types/lodash@4.17.20': {}
 
   '@types/node@22.14.0':
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import type { ESLint } from "eslint";
-import { last } from "lodash-es";
 import packageJson from "../package.json";
 import { rules } from "./rules";
 
@@ -11,7 +10,8 @@ const plugin = {
   processors: {},
 } satisfies ESLint.Plugin;
 
-const pluginShortName = last(plugin.meta.name.split("-")) as string;
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const pluginShortName = plugin.meta.name.split("-").at(-1)!;
 
 const configs = {
   recommended: {

--- a/src/rules/collection-method-value.ts
+++ b/src/rules/collection-method-value.ts
@@ -2,7 +2,6 @@
  * Rule to enforce usage of collection method values.
  */
 
-import { includes } from "lodash-es";
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -26,7 +25,7 @@ function parentUsesValue(node: TSESTree.CallExpression) {
 }
 
 function isSideEffectIterationMethod(method: string) {
-  return includes(getSideEffectIterationMethods(), method);
+  return getSideEffectIterationMethods().includes(method);
 }
 
 function isParentCommit(node: TSESTree.CallExpression, callType: string) {

--- a/src/rules/collection-return.ts
+++ b/src/rules/collection-return.ts
@@ -1,4 +1,3 @@
-import { includes } from "lodash-es";
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -57,7 +56,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
           }
 
           // Side-effect methods like forEach don't need to return values
-          if (includes(getSideEffectIterationMethods(), method)) {
+          if (getSideEffectIterationMethods().includes(method)) {
             return;
           }
 

--- a/src/rules/prefer-filter.ts
+++ b/src/rules/prefer-filter.ts
@@ -89,7 +89,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
       const firstLine = getFirstFunctionLine(func) as
         | TSESTree.IfStatement
         | undefined;
-      const paramName = getFirstParamName(func) as string | undefined;
+      const paramName = getFirstParamName(func);
       const hasOneStatement =
         func.type === AST_NODE_TYPES.ArrowFunctionExpression
           ? func.body.type !== AST_NODE_TYPES.BlockStatement

--- a/src/rules/prefer-has-atleast.ts
+++ b/src/rules/prefer-has-atleast.ts
@@ -2,7 +2,6 @@
  * Rule to check if array.length comparisons or negated isEmpty calls should be replaced with R.hasAtLeast.
  */
 
-import { isEmpty, isNumber } from "lodash-es";
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -32,13 +31,15 @@ function isArrayLengthProperty(
   );
 }
 
-function isNumberLiteral(node: TSESTree.Node): node is TSESTree.Literal {
-  return node.type === AST_NODE_TYPES.Literal && isNumber(node.value);
+function isNumberLiteral(node: TSESTree.Node) {
+  return (
+    node.type === AST_NODE_TYPES.Literal && typeof node.value === "number"
+  );
 }
 
 function getNumberValue(node: TSESTree.Node): number | null {
   if (isNumberLiteral(node)) {
-    return node.value as number;
+    return node.value;
   }
 
   return null;
@@ -70,7 +71,6 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
     ): node is TSESTree.CallExpression {
       return (
         node.type === AST_NODE_TYPES.CallExpression &&
-        // @ts-expect-error
         isCallToRemedaMethod(node, "isEmpty", remedaContext)
       );
     }
@@ -172,7 +172,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
             isEmptyCall = node.right;
           }
 
-          if (isEmptyCall && !isEmpty(isEmptyCall.arguments)) {
+          if (isEmptyCall && isEmptyCall.arguments.length > 0) {
             // Only report if it's a negated comparison (isEmpty === false or isEmpty !== true)
             const isNegated =
               (node.operator === "===" &&
@@ -210,7 +210,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
 
         const isEmptyCall = node.argument;
 
-        if (isEmpty(isEmptyCall.arguments)) {
+        if (isEmptyCall.arguments.length === 0) {
           return;
         }
 

--- a/src/rules/prefer-is-nullish.ts
+++ b/src/rules/prefer-is-nullish.ts
@@ -1,12 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 /**
  * Rule to prefer isNullish over manual checking for undefined or null.
  */
 
-import { cond, find, map, matches, property } from "lodash-es";
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -18,19 +13,75 @@ import { isEquivalentMemberExp } from "../util/isEquivalentMemberExp";
 import { isNegationExpression } from "../util/isNegationExpression";
 import { getRemedaContext, isCallToRemedaMethod } from "../util/remedaUtil";
 
-interface ExpressionNode {
-  type: string;
-  operator: unknown;
-  right: unknown;
-  left: unknown;
-}
-
 export const RULE_NAME = "prefer-is-nullish";
 const PREFER_IS_NULLISH_MESSAGE =
   "Prefer isNullish over checking for undefined or null.";
 
 type MessageIds = "prefer-is-nullish";
 type Options = [];
+
+type Nil = "null" | "undefined";
+
+type ExpressionCheck = (
+  node: TSESTree.Node,
+  operator: string,
+) => TSESTree.Node | false | undefined;
+
+const getTypeofArgument = (node: TSESTree.Node) => {
+  return node.type === AST_NODE_TYPES.UnaryExpression &&
+    node.operator === "typeof"
+    ? node.argument
+    : undefined;
+};
+
+const isUndefinedString = (node: TSESTree.Node) => {
+  return node.type === AST_NODE_TYPES.Literal && node.value === "undefined";
+};
+
+const getValueWithTypeofUndefinedComparison: ExpressionCheck = (
+  node,
+  operator,
+) => {
+  if (
+    node.type !== AST_NODE_TYPES.BinaryExpression ||
+    node.operator !== operator
+  ) {
+    return undefined;
+  }
+
+  return (
+    (isUndefinedString(node.right) && getTypeofArgument(node.left)) ||
+    (isUndefinedString(node.left) && getTypeofArgument(node.right))
+  );
+};
+
+const nilChecksIsValue: Record<Nil, (node: TSESTree.Node) => boolean> = {
+  null: (node) =>
+    node.type === AST_NODE_TYPES.Literal && node.value === null,
+  undefined: (node) =>
+    node.type === AST_NODE_TYPES.Identifier && node.name === "undefined",
+};
+
+const getValueComparedTo = (nil: Nil): ExpressionCheck => {
+  return (node, operator) => {
+    if (
+      node.type !== AST_NODE_TYPES.BinaryExpression ||
+      node.operator !== operator
+    ) {
+      return undefined;
+    }
+
+    if (nilChecksIsValue[nil](node.right)) {
+      return node.left;
+    }
+    
+    if (nilChecksIsValue[nil](node.left)) {
+      return node.right;
+    }
+
+    return undefined;
+  };
+};
 
 export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
   name: RULE_NAME,
@@ -50,58 +101,20 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
   create(context) {
     const remedaContext = getRemedaContext(context);
 
-    function getRemedaTypeCheckedBy(typecheck: string) {
-      // @ts-expect-error
-      return function (node) {
-        return (
-          // @ts-expect-error
-          isCallToRemedaMethod(node, typecheck, remedaContext) &&
-          node.arguments[0]
-        );
+    function getRemedaTypeCheckedBy(typecheck: string): ExpressionCheck {
+      return (node) => {
+        if (
+          node.type !== AST_NODE_TYPES.CallExpression ||
+          !isCallToRemedaMethod(node, typecheck, remedaContext)
+        ) {
+          return undefined;
+        }
+
+        return node.arguments[0];
       };
     }
 
-    const getTypeofArgument = cond([
-      [
-        matches({ type: "UnaryExpression", operator: "typeof" }),
-        property("argument"),
-      ],
-    ]);
-
-    const isUndefinedString = matches({
-      type: "Literal",
-      value: "undefined",
-    });
-
-    function getValueWithTypeofUndefinedComparison(
-      node: ExpressionNode,
-      operator: unknown,
-    ) {
-      return (
-        node.type === "BinaryExpression" &&
-        node.operator === operator &&
-        ((isUndefinedString(node.right) && getTypeofArgument(node.left)) ||
-          (isUndefinedString(node.left) && getTypeofArgument(node.right)))
-      );
-    }
-
-    const nilChecksIsValue = {
-      null: matches({ type: "Literal", value: null }),
-      undefined: matches({ type: "Identifier", name: "undefined" }),
-    };
-
-    function getValueComparedTo(nil: "null" | "undefined") {
-      return function (node: ExpressionNode, operator: unknown) {
-        return (
-          node.type === "BinaryExpression" &&
-          node.operator === operator &&
-          ((nilChecksIsValue[nil](node.right) && node.left) ||
-            (nilChecksIsValue[nil](node.left) && node.right))
-        );
-      };
-    }
-
-    const nilChecksExpressionChecks = {
+    const nilChecksExpressionChecks: Record<Nil, ExpressionCheck[]> = {
       null: [getRemedaTypeCheckedBy("isNull"), getValueComparedTo("null")],
       undefined: [
         getRemedaTypeCheckedBy("isUndefined"),
@@ -110,68 +123,58 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
       ],
     };
 
-    function checkExpression(
-      nil: "null" | "undefined",
-      operator: string,
-      node: { type: string; operator: unknown; right: unknown; left: unknown },
-    ) {
-      const mappedValues = map(nilChecksExpressionChecks[nil], (check) =>
-        check(node, operator),
-      );
+    function checkExpression(nil: Nil, operator: string, node: TSESTree.Node) {
+      for (const check of nilChecksExpressionChecks[nil]) {
+        const result = check(node, operator);
 
-      return find(mappedValues);
+        if (result) {
+          return result;
+        }
+      }
+
+      return undefined;
     }
 
-    function checkNegatedExpression(
-      nil: "null" | "undefined",
-      node: TSESTree.LogicalExpression | TSESTree.UnaryExpression,
-    ) {
-      return (
-        (isNegationExpression(node) &&
-          // @ts-expect-error
-          checkExpression(nil, "===", node.argument)) ||
-        // @ts-expect-error
-        checkExpression(nil, "!==", node)
-      );
+    function checkNegatedExpression(nil: Nil, node: TSESTree.Node) {
+      if (isNegationExpression(node)) {
+        const inner = checkExpression(nil, "===", node.argument);
+
+        if (inner) {
+          return inner;
+        }
+      }
+
+      return checkExpression(nil, "!==", node);
     }
 
     function isEquivalentExistingExpression(
-      node: TSESTree.LogicalExpression | TSESTree.UnaryExpression,
-      leftNil: "null" | "undefined",
-      rightNil: "null" | "undefined",
+      node: TSESTree.LogicalExpression,
+      leftNil: Nil,
+      rightNil: Nil,
     ) {
-      if (node.type !== AST_NODE_TYPES.LogicalExpression) {
+      const leftExp = checkExpression(leftNil, "===", node.left);
+      const rightExp = checkExpression(rightNil, "===", node.right);
+
+      if (!leftExp || !rightExp) {
         return false;
       }
-      // @ts-expect-error
-      const leftExp = checkExpression(leftNil, "===", node.left);
 
-      return (
-        leftExp &&
-        isEquivalentMemberExp(
-          leftExp,
-          // @ts-expect-error
-          checkExpression(rightNil, "===", node.right),
-        )
-      );
+      return isEquivalentMemberExp(leftExp, rightExp);
     }
 
     function isEquivalentExistingNegation(
-      node: TSESTree.LogicalExpression | TSESTree.UnaryExpression,
-      leftNil: "null" | "undefined",
-      rightNil: "null" | "undefined",
+      node: TSESTree.LogicalExpression,
+      leftNil: Nil,
+      rightNil: Nil,
     ) {
-      // @ts-expect-error
       const leftExp = checkNegatedExpression(leftNil, node.left);
+      const rightExp = checkNegatedExpression(rightNil, node.right);
 
-      return (
-        leftExp &&
-        isEquivalentMemberExp(
-          leftExp,
-          // @ts-expect-error
-          checkNegatedExpression(rightNil, node.right),
-        )
-      );
+      if (!leftExp || !rightExp) {
+        return false;
+      }
+
+      return isEquivalentMemberExp(leftExp, rightExp);
     }
 
     const visitors: RemedaMethodVisitors = remedaContext.getImportVisitors();

--- a/src/rules/prefer-map.ts
+++ b/src/rules/prefer-map.ts
@@ -2,7 +2,6 @@
  * Rule to check if a call to R.forEach should be a call to R.map.
  */
 
-import { get, includes } from "lodash-es";
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -11,8 +10,8 @@ import {
 import { collectParameterValues } from "../util/collectParameterValues";
 import { getDocsUrl } from "../util/getDocsUrl";
 import { getFirstFunctionLine } from "../util/getFirstFunctionLine";
-import { getMethodName } from "../util/getMethodName";
 import { hasOnlyOneStatement } from "../util/hasOnlyOneStatement";
+import { isFunctionDefinition } from "../util/isFunctionDefinition";
 import { isFunctionDefinitionWithBlock } from "../util/isFunctionDefinitionWithBlock";
 import { getRemedaMethodVisitors } from "../util/remedaUtil";
 
@@ -20,34 +19,41 @@ export const RULE_NAME = "prefer-map";
 type MessageIds = "prefer-map";
 type Options = [];
 
-function onlyHasPush(
-  node:
-    | TSESTree.ArrowFunctionExpression
-    | TSESTree.FunctionDeclaration
-    | TSESTree.FunctionExpression
-    | null
-    | undefined,
-) {
-  const firstLine = getFirstFunctionLine(node);
-  const firstParam = get(node, "params[0]");
-  const exp =
-    node && !isFunctionDefinitionWithBlock(node)
-      ? firstLine
-      : //@ts-expect-error
-        firstLine?.expression;
+const onlyHasPush = (node: TSESTree.Node) => {
+  if (!isFunctionDefinition(node)) {
+    return false;
+  }
 
-  return (
-    node &&
-    (node.type === AST_NODE_TYPES.ArrowFunctionExpression
-      ? true
-      : hasOnlyOneStatement(node)) &&
-    getMethodName(exp) === "push" &&
-    !includes(
-      collectParameterValues(firstParam),
-      get(exp, "callee.object.name"),
-    )
+  if (
+    node.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+    !hasOnlyOneStatement(node)
+  ) {
+    return false;
+  }
+
+  const firstLine = getFirstFunctionLine(node);
+  // eslint-disable-next-line no-nested-ternary
+  const exp = isFunctionDefinitionWithBlock(node) ? firstLine?.type === AST_NODE_TYPES.ExpressionStatement
+        ? firstLine.expression
+        : undefined : firstLine;
+
+  if (
+    exp?.type !== AST_NODE_TYPES.CallExpression ||
+    exp.callee.type !== AST_NODE_TYPES.MemberExpression ||
+    exp.callee.property.type !== AST_NODE_TYPES.Identifier ||
+    exp.callee.property.name !== "push"
+  ) {
+    return false;
+  }
+  
+  if (exp.callee.object.type !== AST_NODE_TYPES.Identifier) {
+    return true;
+  }
+
+  return !collectParameterValues(node.params[0]).includes(
+    exp.callee.object.name,
   );
-}
+};
 
 export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
   name: RULE_NAME,
@@ -73,15 +79,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         iteratee: TSESTree.Node,
         { method }: { method: string },
       ) => {
-        if (
-          method === "forEach" &&
-          onlyHasPush(
-            iteratee as
-              | TSESTree.ArrowFunctionExpression
-              | TSESTree.FunctionDeclaration
-              | TSESTree.FunctionExpression,
-          )
-        ) {
+        if (method === "forEach" && onlyHasPush(iteratee)) {
           context.report({
             node,
             messageId: "prefer-map",

--- a/src/rules/prefer-remeda-typecheck.ts
+++ b/src/rules/prefer-remeda-typecheck.ts
@@ -2,7 +2,6 @@
  * Rule to check if there's a method in the chain start that can be in the chain.
  */
 
-import { some } from "lodash-es";
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -52,7 +51,7 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
       const scope = sourceCode.getScope(node);
       const definedVariables = scope.variables;
 
-      return some(definedVariables, { name: node.name });
+      return definedVariables.some((v) => v.name === node.name);
     }
 
     function getValueForSide(

--- a/src/rules/prefer-times.ts
+++ b/src/rules/prefer-times.ts
@@ -2,9 +2,12 @@
  * Rule to check if a call to map should be a call to times.
  */
 
-import { get } from "lodash-es";
-import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+import {
+  ESLintUtils,
+  type TSESTree,
+} from "@typescript-eslint/utils";
 import { getDocsUrl } from "../util/getDocsUrl";
+import { isFunctionDefinition } from "../util/isFunctionDefinition";
 import { getRemedaMethodVisitors } from "../util/remedaUtil";
 
 export const RULE_NAME = "prefer-times";
@@ -34,7 +37,11 @@ export default ESLintUtils.RuleCreator(getDocsUrl)<Options, MessageIds>({
         iteratee: TSESTree.Node,
         { method }: { method: string },
       ) => {
-        if (method === "map" && get(iteratee, "params.length") === 0) {
+        if (
+          method === "map" &&
+          isFunctionDefinition(iteratee) &&
+          iteratee.params.length === 0
+        ) {
           context.report({
             node,
             messageId: "prefer-times",

--- a/src/util/collectParameterValues.ts
+++ b/src/util/collectParameterValues.ts
@@ -1,4 +1,3 @@
-import { flatMap } from "lodash-es";
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 /**
@@ -15,12 +14,14 @@ function collectParameterValues(
       return [node.name];
     }
     case AST_NODE_TYPES.ObjectPattern: {
-      return flatMap(node.properties, (prop) =>
-        collectParameterValues(prop.value),
-      );
+      return node.properties.flatMap((prop) => {
+        return prop.type === AST_NODE_TYPES.Property
+          ? collectParameterValues(prop.value)
+          : [];
+      });
     }
     case AST_NODE_TYPES.ArrayPattern: {
-      return flatMap(node.elements, collectParameterValues);
+      return node.elements.flatMap(collectParameterValues);
     }
     default: {
       return [];

--- a/src/util/getExpressionComparedToInt.ts
+++ b/src/util/getExpressionComparedToInt.ts
@@ -1,4 +1,3 @@
-import { includes } from "lodash-es";
 import type { TSESTree } from "@typescript-eslint/utils";
 import { comparisonOperators } from "./comparisonOperators";
 import { getIsValue } from "./getIsValue";
@@ -17,7 +16,7 @@ function getExpressionComparedToInt(
 ): TSESTree.Node | undefined {
   const isValue = getIsValue(value);
 
-  if (includes(comparisonOperators, node.operator)) {
+  if (comparisonOperators.includes(node.operator)) {
     if (isValue(node.right)) {
       return node.left;
     }

--- a/src/util/getFirstParamName.ts
+++ b/src/util/getFirstParamName.ts
@@ -1,10 +1,21 @@
-import { property } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 /**
  * Returns the name of the first parameter of a function, if it exists.
  *
  * @param func - The function to check.
  */
-const getFirstParamName = property("params[0].name");
+const getFirstParamName = (func: TSESTree.Node | null | undefined) => {
+  if (
+    func?.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
+    func?.type !== AST_NODE_TYPES.FunctionExpression &&
+    func?.type !== AST_NODE_TYPES.FunctionDeclaration
+  ) {
+    return undefined;
+  }
+  const first = func.params[0];
+
+  return first?.type === AST_NODE_TYPES.Identifier ? first.name : undefined;
+};
 
 export { getFirstParamName };

--- a/src/util/getIsValue.ts
+++ b/src/util/getIsValue.ts
@@ -1,12 +1,17 @@
-import { matches, overEvery } from "lodash-es";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 import { isMinus } from "./isMinus";
 
-type GetIsValueReturn = (node: TSESTree.Node) => boolean;
+export const getIsValue = (value: number) => {
+  if (value < 0) {
+    return (node: TSESTree.Node) => {
+      return (
+        isMinus(node) &&
+        node.argument.type === AST_NODE_TYPES.Literal &&
+        node.argument.value === -value
+      );
+    };
+  }
 
-export const getIsValue = (value: number): GetIsValueReturn => {
-  return value < 0
-    ? // eslint-disable-next-line
-      overEvery(isMinus, matches({ argument: { value: -value } }))
-    : matches({ value });
+  return (node: TSESTree.Node) =>
+    node.type === AST_NODE_TYPES.Literal && node.value === value;
 };

--- a/src/util/getMethodName.ts
+++ b/src/util/getMethodName.ts
@@ -1,10 +1,20 @@
-import { property } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 /**
  * Gets the name of a method in a CallExpression.
  *
  * @param node - The node to check.
  */
-const getMethodName = property("callee.property.name");
+const getMethodName = (node: TSESTree.Node) => {
+  if (
+    node.type === AST_NODE_TYPES.CallExpression &&
+    node.callee.type === AST_NODE_TYPES.MemberExpression &&
+    node.callee.property.type === AST_NODE_TYPES.Identifier
+  ) {
+    return node.callee.property.name;
+  }
+
+  return undefined;
+};
 
 export { getMethodName };

--- a/src/util/getSettings.ts
+++ b/src/util/getSettings.ts
@@ -1,4 +1,3 @@
-import { defaults, get } from "lodash-es";
 import type { ESLintContext } from "../types";
 
 interface RemedaSettings {
@@ -7,7 +6,7 @@ interface RemedaSettings {
 }
 
 export function getSettings(context: ESLintContext): RemedaSettings {
-  return defaults(get(context, "settings.remeda", {}), {
-    version: 4,
-  });
+  const remedaSettings = context.settings?.remeda;
+  
+  return { ...remedaSettings, version: remedaSettings?.version ?? 4 };  
 }

--- a/src/util/hasOnlyOneStatement.ts
+++ b/src/util/hasOnlyOneStatement.ts
@@ -1,4 +1,4 @@
-import { get } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 import { isFunctionDefinitionWithBlock } from "./isFunctionDefinitionWithBlock";
 
 /**
@@ -6,20 +6,14 @@ import { isFunctionDefinitionWithBlock } from "./isFunctionDefinitionWithBlock";
  *
  * @param func - The function to check.
  */
-function hasOnlyOneStatement(func: {
-  type: string;
-  body: { body?: unknown };
-}): boolean {
+const hasOnlyOneStatement = (func: TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression) => {
   if (isFunctionDefinitionWithBlock(func)) {
-    const body = get(func, "body.body");
-
-    return Array.isArray(body) && body.length === 1;
-  }
-  if (func.type === "ArrowFunctionExpression") {
-    return !get(func, "body.body");
+    return func.body.body.length === 1;
   }
 
-  return false;
-}
+  return func.type === AST_NODE_TYPES.ArrowFunctionExpression;
+};
 
 export { hasOnlyOneStatement };

--- a/src/util/importUtil.ts
+++ b/src/util/importUtil.ts
@@ -1,15 +1,15 @@
-import { get } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
-interface RequireCall {
-  callee: { name: string };
-  arguments: { type: string; value: string }[];
-}
-
-function getNameFromCjsRequire(init: RequireCall): string | undefined {
+function getNameFromCjsRequire(
+  init: TSESTree.Node | null | undefined,
+): string | undefined {
   if (
-    get(init, "callee.name") === "require" &&
-    get(init, "arguments.length") === 1 &&
-    init.arguments[0].type === "Literal"
+    init?.type === AST_NODE_TYPES.CallExpression &&
+    init.callee.type === AST_NODE_TYPES.Identifier &&
+    init.callee.name === "require" &&
+    init.arguments.length === 1 &&
+    init.arguments[0].type === AST_NODE_TYPES.Literal &&
+    typeof init.arguments[0].value === "string"
   ) {
     return init.arguments[0].value;
   }

--- a/src/util/isBinaryExpWithMemberOf.ts
+++ b/src/util/isBinaryExpWithMemberOf.ts
@@ -1,4 +1,3 @@
-import { isMatch } from "lodash-es";
 import type { TSESTree } from "@typescript-eslint/utils";
 import { isLiteral } from "./isLiteral";
 import { isMemberExpOf } from "./isMemberExpOf";
@@ -22,7 +21,7 @@ function isBinaryExpWithMemberOf(
     onlyLiterals,
   }: IsBinaryExpWithMemberOfOptions = {},
 ) {
-  if (!isMatch(exp, { type: "BinaryExpression", operator })) {
+  if (exp.operator !== operator) {
     return false;
   }
   const [left, right] = [exp.left, exp.right].map((side) =>

--- a/src/util/isCallFromObject.ts
+++ b/src/util/isCallFromObject.ts
@@ -1,4 +1,3 @@
-import { get } from "lodash-es";
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 /**
@@ -7,16 +6,17 @@ import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
  * @param node - The node to check.
  * @param objName   - The object name to check against.
  */
-function isCallFromObject(
+const isCallFromObject = (
   node: TSESTree.Node | null | undefined,
   objName: string,
-) {
+) => {
   return (
-    node &&
-    objName &&
-    node.type === AST_NODE_TYPES.CallExpression &&
-    get(node, "callee.object.name") === objName
+    Boolean(objName) &&
+    node?.type === AST_NODE_TYPES.CallExpression &&
+    node.callee.type === AST_NODE_TYPES.MemberExpression &&
+    node.callee.object.type === AST_NODE_TYPES.Identifier &&
+    node.callee.object.name === objName
   );
-}
+};
 
 export { isCallFromObject };

--- a/src/util/isComputed.ts
+++ b/src/util/isComputed.ts
@@ -1,4 +1,3 @@
-import { get } from "lodash-es";
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 /**
@@ -6,8 +5,8 @@ import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
  *
  * @param node - The node to check.
  */
-function isComputed(node: TSESTree.MemberExpression): boolean {
-  return get(node, "computed") && node.property.type !== AST_NODE_TYPES.Literal;
+function isComputed(node: TSESTree.MemberExpression) {
+  return node.computed && node.property.type !== AST_NODE_TYPES.Literal;
 }
 
 export { isComputed };

--- a/src/util/isEquivalentMemberExp.ts
+++ b/src/util/isEquivalentMemberExp.ts
@@ -1,59 +1,57 @@
-import { includes, isEqualWith } from "lodash-es";
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 import { isComputed } from "./isComputed";
 
+function isEquivalentLeaf(a: TSESTree.Node, b: TSESTree.Node): boolean {
+  if (
+    a.type === AST_NODE_TYPES.Identifier &&
+    b.type === a.type
+  ) {
+    return a.name === b.name;
+  }
+
+  if (
+    a.type === AST_NODE_TYPES.Literal &&
+    b.type === a.type
+  ) {
+    return a.value === b.value;
+  }
+
+  return false;
+}
+
 /**
- * Returns whether the two expressions refer to the same object (e.g. A['b'].c and a.b.c).
+ * Returns whether the two expressions structurally refer to the same value
+ * (e.g. `a['b'].c` and `a.b.c`, or two identical identifiers / literals).
+ * Handles MemberExpression chains, Identifier names, Literal values, and ThisExpression.
+ * Source positions and parent links are ignored.
  *
  * @param a - The first expression to check.
  * @param b - The second expression to check.
  */
-function isEquivalentMemberExp(
-  a: TSESTree.MemberExpression,
-  b: TSESTree.MemberExpression,
-) {
-  return isEqualWith(
-    a,
-    b,
-    (
-      left: TSESTree.Node | undefined,
-      right: TSESTree.Node | undefined,
-      key: PropertyKey | undefined,
-    ) => {
-      if (!left || !right || !key) {
-        return undefined;
-      }
-      if (
-        includes(["loc", "range", "computed", "start", "end", "parent"], key)
-      ) {
-        return true;
-      }
-      if (
-        isComputed(left as TSESTree.MemberExpression) ||
-        isComputed(right as TSESTree.MemberExpression)
-      ) {
-        return false;
-      }
-      if (key === "property") {
-        if (
-          left.type === AST_NODE_TYPES.Identifier &&
-          right.type === AST_NODE_TYPES.Identifier
-        ) {
-          return left.name === right.name;
-        }
-        if (
-          left.type === AST_NODE_TYPES.Literal &&
-          right.type === AST_NODE_TYPES.Literal
-        ) {
-          return left.value === right.value;
-        }
+function isEquivalentMemberExp(a: TSESTree.Node, b: TSESTree.Node): boolean {
+  if (a.type !== b.type) {
+    return false;
+  }
 
-        return false;
-      }
+  if (
+    a.type === AST_NODE_TYPES.MemberExpression &&
+    b.type === AST_NODE_TYPES.MemberExpression
+  ) {
+    if (isComputed(a) || isComputed(b)) {
+      return false;
+    }
 
-      return undefined;
-    },
-  );
+    return (
+      isEquivalentLeaf(a.property, b.property) &&
+      isEquivalentMemberExp(a.object, b.object)
+    );
+  }
+  
+  if (a.type === AST_NODE_TYPES.ThisExpression) {
+    return true;
+  }
+
+  return isEquivalentLeaf(a, b);
 }
 
 export { isEquivalentMemberExp };

--- a/src/util/isFunctionDefinition.ts
+++ b/src/util/isFunctionDefinition.ts
@@ -1,0 +1,11 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+const isFunctionDefinition = (node: TSESTree.Node) => {
+  return (
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression
+  );
+};
+
+export { isFunctionDefinition };

--- a/src/util/isFunctionDefinitionWithBlock.ts
+++ b/src/util/isFunctionDefinitionWithBlock.ts
@@ -1,18 +1,22 @@
-import { matches, overSome } from "lodash-es";
-import { isFunctionExpression } from "./isFunctionExpression";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { isFunctionDefinition } from "./isFunctionDefinition";
 
 /**
  * Returns whether the node is a function declaration that has a block.
  *
  * @param node - The node to check.
  */
-const isFunctionDefinitionWithBlock = overSome(
-  isFunctionExpression,
-  // eslint-disable-next-line
-  matches({
-    type: "ArrowFunctionExpression",
-    body: { type: "BlockStatement" },
-  }),
-);
+const isFunctionDefinitionWithBlock = (
+  node: TSESTree.Node,
+): node is
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression
+  | (TSESTree.ArrowFunctionExpression & { body: TSESTree.BlockStatement }) => {
+  return (
+    isFunctionDefinition(node) &&
+    !(node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+      node.body.type !== AST_NODE_TYPES.BlockStatement)
+  );
+};
 
 export { isFunctionDefinitionWithBlock };

--- a/src/util/isFunctionExpression.ts
+++ b/src/util/isFunctionExpression.ts
@@ -1,9 +1,0 @@
-import { matchesProperty, overSome } from "lodash-es";
-
-const isFunctionExpression = overSome(
-  matchesProperty("type", "FunctionExpression"),
-  // eslint-disable-next-line
-  matchesProperty("type", "FunctionDeclaration"),
-);
-
-export { isFunctionExpression };

--- a/src/util/isMethodCall.ts
+++ b/src/util/isMethodCall.ts
@@ -1,13 +1,15 @@
-import { matches } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 /**
  * Returns whether the node is a method call.
  *
  * @param node - The node to check.
  */
-const isMethodCall = matches({
-  type: "CallExpression",
-  callee: { type: "MemberExpression" },
-});
+const isMethodCall = (node: TSESTree.Node) => {
+  return (
+    node.type === AST_NODE_TYPES.CallExpression &&
+    node.callee.type === AST_NODE_TYPES.MemberExpression
+  );
+};
 
 export { isMethodCall };

--- a/src/util/isMinus.ts
+++ b/src/util/isMinus.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
-const isMinus = (node: TSESTree.Node | null | undefined) => {
-  return node?.type === AST_NODE_TYPES.UnaryExpression && node.operator === "-";
+const isMinus = (node: TSESTree.Node) => {
+  return node.type === AST_NODE_TYPES.UnaryExpression && node.operator === "-";
 };
 
 export { isMinus };

--- a/src/util/isNegationExpression.ts
+++ b/src/util/isNegationExpression.ts
@@ -1,13 +1,12 @@
-import { matches } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
 /**
  * Returns whether the expression is a negation.
  *
  * @param exp - The expression to check.
  */
-const isNegationExpression = matches({
-  type: "UnaryExpression",
-  operator: "!",
-});
+const isNegationExpression = (exp: TSESTree.Node) => {
+  return exp.type === AST_NODE_TYPES.UnaryExpression && exp.operator === "!";
+};
 
 export { isNegationExpression };

--- a/src/util/isPropAccess.ts
+++ b/src/util/isPropAccess.ts
@@ -1,9 +1,10 @@
-import { matches, matchesProperty, overSome } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
-const isPropAccess = overSome(
-  matches({ computed: false }),
-  // eslint-disable-next-line
-  matchesProperty("property.type", "Literal"),
-);
+const isPropAccess = (node: TSESTree.Node) => {
+  return (
+    node.type === AST_NODE_TYPES.MemberExpression &&
+    (!node.computed || node.property.type === AST_NODE_TYPES.Literal)
+  );
+};
 
 export { isPropAccess };

--- a/src/util/isReturnStatement.ts
+++ b/src/util/isReturnStatement.ts
@@ -1,5 +1,7 @@
-import { matchesProperty } from "lodash-es";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 
-const isReturnStatement = matchesProperty("type", "ReturnStatement");
+const isReturnStatement = (node: TSESTree.Node) => {
+  return node.type === AST_NODE_TYPES.ReturnStatement;
+};
 
 export { isReturnStatement };

--- a/src/util/methodDataUtil.ts
+++ b/src/util/methodDataUtil.ts
@@ -1,4 +1,3 @@
-import { has, includes, isObject } from "lodash-es";
 import type { MethodData } from "../types";
 import * as methodDataCatalog from "./methodData";
 
@@ -24,7 +23,8 @@ function methodSupportsShorthand(method: string, shorthandType?: string) {
   const methodData = methodDataCatalog[method];
 
   const methodShorthandData = methodData.shorthand;
-  const isShorthandObject = isObject(methodShorthandData);
+  const isShorthandObject =
+    typeof methodShorthandData === "object" && methodShorthandData !== null;
 
   return isShorthandObject
     ? // @ts-expect-error
@@ -46,7 +46,8 @@ function isCollectionMethod(method: string) {
 
   return (
     methodSupportsShorthand(method) ||
-    includes(["reduce", "reduceRight"], method) ||
+    method === "reduce" ||
+    method === "reduceRight" ||
     Boolean(methodData.iteratee)
   );
 }
@@ -59,7 +60,7 @@ function getIterateeIndex(method: string) {
   const methodData: MethodData | undefined = methodDataCatalog[method];
 
   if (methodData) {
-    if (has(methodData, "iterateeIndex")) {
+    if (Object.hasOwn(methodData, "iterateeIndex")) {
       return methodData.iterateeIndex;
     }
     if (methodData.iteratee) {

--- a/src/util/remedaUtil.ts
+++ b/src/util/remedaUtil.ts
@@ -1,9 +1,10 @@
-import { capitalize, includes, isNumber, isString } from "lodash-es";
 import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 import type { ESLintContext, RemedaMethodVisitors } from "../types";
 import { getMethodName } from "./getMethodName";
 import * as methodDataUtil from "./methodDataUtil";
 import RemedaContext from "./RemedaContext";
+
+const capitalize = (string: string) => { return `${string.charAt(0).toUpperCase()}${string.slice(1)}` }
 
 /**
  * Returns whether the node is a call to the specified method.
@@ -36,7 +37,9 @@ function getIsTypeMethod(name: string) {
     // "Element",
   ];
 
-  return includes(types, name) ? `is${capitalize(name)}` : null;
+  return types.includes(name)
+    ? `is${capitalize(name)}`
+    : null;
 }
 
 /**
@@ -64,13 +67,13 @@ function getRemedaMethodCallExpVisitor(
     if (remedaContext.isRemedaCall(node)) {
       const method = getMethodName(node);
 
-      if (!isString(method)) {
+      if (typeof method !== "string") {
         return;
       }
 
       iterateeIndex = methodDataUtil.getIterateeIndex(method);
 
-      if (isNumber(iterateeIndex)) {
+      if (typeof iterateeIndex === "number") {
         reporter(node, node.arguments[iterateeIndex], {
           callType: "method",
           method,
@@ -82,7 +85,7 @@ function getRemedaMethodCallExpVisitor(
 
       if (method) {
         iterateeIndex = methodDataUtil.getIterateeIndex(method);
-        if (isNumber(iterateeIndex)) {
+        if (typeof iterateeIndex === "number") {
           reporter(node, node.arguments[iterateeIndex], {
             method,
             callType: "single",
@@ -95,24 +98,17 @@ function getRemedaMethodCallExpVisitor(
 }
 
 function isRemedaCallToMethod(
-  node: TSESTree.Node | null | undefined,
+  node: TSESTree.Node,
   method: string,
-  remedaContext: { isRemedaCall: (node: unknown) => boolean },
-): boolean {
-  if (!node) {
-    return false;
-  }
-
+  remedaContext: RemedaContext,
+) {
   return remedaContext.isRemedaCall(node) && isCallToMethod(node, method);
 }
 
 function isCallToRemedaMethod(
   node: TSESTree.Node | null | undefined,
   method: string,
-  remedaContext: {
-    getImportedRemedaMethod: (node: unknown) => string;
-    isRemedaCall: (node: unknown) => boolean;
-  },
+  remedaContext: RemedaContext,
 ): boolean {
   if (!node || node.type !== AST_NODE_TYPES.CallExpression) {
     return false;

--- a/tests/lib/testUtil/optionsUtil.ts
+++ b/tests/lib/testUtil/optionsUtil.ts
@@ -1,5 +1,3 @@
-import { isString } from "lodash-es";
-
 type TestCase = string | { code: string; [key: string]: unknown };
 type TestOptions = Record<string, unknown>;
 interface TestCaseResult {
@@ -11,7 +9,7 @@ function fromOptions(
   options: TestOptions,
 ): (testCase: TestCase) => TestCaseResult {
   return function (testCase: TestCase): TestCaseResult {
-    if (isString(testCase)) {
+    if (typeof testCase === "string") {
       return { code: testCase, ...options };
     }
 


### PR DESCRIPTION
Hello!

I've noticed that this plugin uses quite heavy and poorly maintained `lodash-es` dependency (which also recently got some vulnerabilities).

Given most of the methods can be trivially or easily replaced, I've refactored the codebase to completely get rid of this dependency 🙂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed lodash-es usage across the codebase and replaced it with native JavaScript and more type-safe utilities.
  * Cleaned devDependencies (removed lodash-es types) and tightened type-checking/tooling.
  * Improved internal AST/type detection and simplified rule logic for consistency.
  * Disabled lodash integration in ESLint configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AndreaPontrandolfo/eslint-plugin-remeda/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->